### PR TITLE
Sdcard pio spi

### DIFF
--- a/Kernel/platform-rpipico/CMakeLists.txt
+++ b/Kernel/platform-rpipico/CMakeLists.txt
@@ -8,6 +8,11 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_BUILD_TYPE Debug)
 set(PICO_COPY_TO_RAM 1)
 
+# Makefile modified to set up SD_PIO_SPI_SET of GPIO's
+# depends on choosing between 'pico' or 'vgaboard'
+# see Makefile
+add_definitions(-DSD_PIO_SPI_SET=$(SD_PIO_SPI_SET))
+
 pico_sdk_init()
 include_directories(
 	.
@@ -17,12 +22,21 @@ include_directories(
 	../cpu-armm0
 )
 
-add_executable(fuzix
+
+
+add_executable(fuzix)
+
+pico_generate_pio_header(fuzix ${CMAKE_CURRENT_LIST_DIR}/spi_sdcard.pio)
+
+
+target_sources(fuzix PRIVATE
 	devices.c
 	devflash.c
 	devsdspi.c
+	pio_spi_sdcard.c
+	pio_spi_sdcard.h
 	devtty.c
-	elf.c 
+	elf.c
 	main.c
 	misc.c
 	rawflash.c
@@ -61,9 +75,11 @@ add_executable(fuzix
 target_link_libraries(fuzix
 	pico_stdlib
 	hardware_flash
-	hardware_spi
+#	hardware_spi
 	hardware_uart
 	hardware_timer
+	hardware_pio
 )
+
 pico_add_extra_outputs(fuzix)
 

--- a/Kernel/platform-rpipico/Makefile
+++ b/Kernel/platform-rpipico/Makefile
@@ -1,5 +1,17 @@
-export PICO_SDK_PATH = /home/dg/src/pico/pico-sdk
-
+#export PICO_SDK_PATH = /home/dg/src/pico/pico-sdk
+export PICO_SDK_PATH = /home/pi/pico/pico-sdk
+#set PICO_BOARD_KIND to either pico or vgaboard
+PICO_BOARD_KIND = vgaboard
+#PICO_BOARD_KIND = pico
+ifeq ($(PICO_BOARD_KIND), pico)
+export SD_PIO_SPI_SET = 1
+else
+ifeq ($(PICO_BOARD_KIND), vgaboard)
+export SD_PIO_SPI_SET = 2
+else
+$(error board not supported)
+endif
+endif
 build/fuzix.elf: ../version.c build/Makefile
 	$(MAKE) -C build
 
@@ -8,7 +20,9 @@ build/fuzix.elf: ../version.c build/Makefile
 
 build/Makefile: CMakeLists.txt $(wildcard ../*.[chS]) $(wildcard ../*/*.[chS])
 	mkdir -p build
-	(cd build && cmake ..)
+	(cd build && cmake -D"PICO_BOARD=$(PICO_BOARD_KIND)" .. )
+#	(cd build && cmake -D"PICO_BOARD=vgaboard" ..)
+#	(cd build && cmake ..)
 
 clean:
 	rm -rf build

--- a/Kernel/platform-rpipico/Makefile
+++ b/Kernel/platform-rpipico/Makefile
@@ -1,8 +1,9 @@
-#export PICO_SDK_PATH = /home/dg/src/pico/pico-sdk
-export PICO_SDK_PATH = /home/pi/pico/pico-sdk
+export PICO_SDK_PATH = /home/dg/src/pico/pico-sdk
+#export PICO_SDK_PATH = /home/pi/pico/pico-sdk
+
 #set PICO_BOARD_KIND to either pico or vgaboard
-PICO_BOARD_KIND = vgaboard
-#PICO_BOARD_KIND = pico
+#PICO_BOARD_KIND = vgaboard
+PICO_BOARD_KIND = pico
 ifeq ($(PICO_BOARD_KIND), pico)
 export SD_PIO_SPI_SET = 1
 else

--- a/Kernel/platform-rpipico/devsdspi.c
+++ b/Kernel/platform-rpipico/devsdspi.c
@@ -9,59 +9,130 @@
 #include "picosdk.h"
 #include "globals.h"
 #include "config.h"
-#include <hardware/spi.h>
+
+#include "pio_spi_sdcard.h"
+
+/*
+ * REWIRE MAP FOR PICO BREADBOARD to VGABOARD BREADBOARD LAYOUT
+ * PPINx = PhysicalPinx
+ * UART TX = GREEN, happen to be using GREEN for SCK also
+ * WHITE    RXD (U0)PPIN1   ->  (U1)PPIN26
+ * GREEN    TXD (U0)PPIN2   ->  (U1)PPIN27
+ * RED      3v3
+ * YELLOW   MISO    PPIN16  ->  PPIN25
+ * BLUE     CS	    PPIN17  ->  PPIN29
+ * BLACK    GND
+ * GREEN    SCK	    PPIN19  ->  PPIN7
+ * ORANGE   MOSI    PPIN20  ->  PPIN24
+*/
+
+#if SD_PIO_SPI_SET == 1 /*pico*/
+/* Match current hardware spi layout on pico
+ * GPIO12   PIN16   MISO
+ * GPIO13   PIN17   CS
+ * GPIO14   PIN19   SCK
+ * GPIO15   PIN20   MOSI
+ */
+#define PIN_MISO 12
+#define PIN_CS   13
+#define PIN_SCK  14
+#define PIN_MOSI 15
+#elif SD_PIO_SPI_SET == 2 /*vgaboard*/
+/* With pimoroni version will have to cut tracks GPIO20/GPIO21 for U1
+ * GPIO5    PIN7    SCK
+ * GPIO18   PIN24   MOSI
+ * GPIO19   PIN25   MISO
+ * GPIO22   PIN29   CS
+ */
+#define PIN_MISO 19
+#define PIN_CS   22
+#define PIN_SCK   5
+#define PIN_MOSI 18
+#else
+#error "Unsupported SD_PIO_SPI_SET take a look at the Makefile"
+#endif
+
+    pio_spi_inst_t spi = {
+        .pio = pio0,
+        .sm = 0,
+        .cs_pin = PIN_CS
+    };
 
 void sd_rawinit(void)
 {
+    gpio_init(PIN_CS);
+    gpio_put(PIN_CS, 1);
+    gpio_set_dir(PIN_CS, GPIO_OUT);
 
-    gpio_init_mask(0xf << 12);
-    gpio_set_function(12, GPIO_FUNC_SPI);
-    gpio_set_function(13, GPIO_FUNC_SIO);
-    gpio_set_function(14, GPIO_FUNC_SPI);
-    gpio_set_function(15, GPIO_FUNC_SPI);
-    gpio_set_dir(13, true);
+    uint offset = pio_add_program(spi.pio, &spi_cpha0_program);
+//    kprintf("Loaded program at %d\n", offset);
 
-    spi_init(spi1, 250000);
-    spi_set_format(spi1, 8, 0, 0, SPI_MSB_FIRST);
+    pio_spi_init(spi.pio, spi.sm, offset,
+//                 8,       // 8 bits per SPI frame
+                 125.0000f,  // 0.25 MHz @ 125 clk_sys
+//                 false,   // CPHA = 0
+//                 false,   // CPOL = 0
+                 PIN_SCK,
+                 PIN_MOSI,
+                 PIN_MISO
+    );
 }
 
 void sd_spi_clock(bool go_fast)
 {
-    spi_set_baudrate(spi1, go_fast ? 4000000 : 250000);
+/*
+*  250000Hz = 125.0000f
+* 1000000Hz =  31.2500f
+* 4000000Hz =   7.8125f
+*/
+    pio_spi_disable(spi.pio, spi.sm);
+    pio_sm_clear_fifos(spi.pio, spi.sm); //not sure if needed
+
+    if (go_fast)
+    {
+        pio_sm_set_clkdiv(spi.pio, spi.sm, 7.8125f);
+    }
+    else
+    {
+        pio_sm_set_clkdiv(spi.pio, spi.sm, 125.0000f);
+    }
+
+    pio_spi_enable(spi.pio, spi.sm);
+
 }
 
 void sd_spi_raise_cs(void)
 {
-    gpio_put(1<<13, true);
+    gpio_put(spi.cs_pin, true);
 }
 
 void sd_spi_lower_cs(void)
 {
-    gpio_put(1<<13, false);
+    gpio_put(spi.cs_pin, false);
 }
 
 void sd_spi_transmit_byte(uint_fast8_t b)
 {
-    spi_write_blocking(spi1, (uint8_t*) &b, 1);
+    pio_spi_write8_blocking(&spi, (uint8_t*) &b, 1);
 }
 
 uint_fast8_t sd_spi_receive_byte(void)
 {
     uint8_t b;
-    spi_read_blocking(spi1, 0xff, (uint8_t*) &b, 1);
+    pio_spi_read8_blocking(&spi, (uint8_t*) &b, 1);
     return b;
 }
 
 bool sd_spi_receive_sector(void)
 {
-    spi_read_blocking(spi1, 0xff, (uint8_t*) blk_op.addr, 512);
-	return 0;
+    pio_spi_read8_blocking(&spi, (uint8_t*) blk_op.addr, 512);
+    return 0;
 }
 
 bool sd_spi_transmit_sector(void)
 {
-    spi_write_blocking(spi1,  (uint8_t*) blk_op.addr, 512);
-	return 0;
+    pio_spi_write8_blocking(&spi, (uint8_t*) blk_op.addr, 512);
+    return 0;
 }
 
 /* vim: sw=4 ts=4 et: */

--- a/Kernel/platform-rpipico/pio_spi_sdcard.c
+++ b/Kernel/platform-rpipico/pio_spi_sdcard.c
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// 2021mar06 mods to pio/spi example
+// write 0xff cmd when reading from SDCard
+
+#include "pio_spi_sdcard.h"
+
+// Just 8 bit functions provided here. The PIO program supports any frame size
+// 1...32, but the software to do the necessary FIFO shuffling is left as an
+// exercise for the reader :)
+//
+// Likewise we only provide MSB-first here. To do LSB-first, you need to
+// - Do shifts when reading from the FIFO, for general case n != 8, 16, 32
+// - Do a narrow read at a one halfword or 3 byte offset for n == 16, 8
+// in order to get the read data correctly justified. 
+
+void __time_critical_func(pio_spi_write8_blocking)(const pio_spi_inst_t *spi, const uint8_t *src, size_t len) {
+    size_t tx_remain = len, rx_remain = len;
+    // Do 8 bit accesses on FIFO, so that write data is byte-replicated. This
+    // gets us the left-justification for free (for MSB-first shift-out)
+    io_rw_8 *txfifo = (io_rw_8 *) &spi->pio->txf[spi->sm];
+    io_rw_8 *rxfifo = (io_rw_8 *) &spi->pio->rxf[spi->sm];
+    while (tx_remain || rx_remain) {
+        if (tx_remain && !pio_sm_is_tx_fifo_full(spi->pio, spi->sm)) {
+            *txfifo = *src++;
+            --tx_remain;
+        }
+        if (rx_remain && !pio_sm_is_rx_fifo_empty(spi->pio, spi->sm)) {
+            (void) *rxfifo;
+            --rx_remain;
+        }
+    }
+}
+
+void __time_critical_func(pio_spi_read8_blocking)(const pio_spi_inst_t *spi, uint8_t *dst, size_t len) {
+    size_t tx_remain = len, rx_remain = len;
+    io_rw_8 *txfifo = (io_rw_8 *) &spi->pio->txf[spi->sm];
+    io_rw_8 *rxfifo = (io_rw_8 *) &spi->pio->rxf[spi->sm];
+    while (tx_remain || rx_remain) {
+        if (tx_remain && !pio_sm_is_tx_fifo_full(spi->pio, spi->sm)) {
+//            *txfifo = 0;
+            *txfifo = 0xff;  //0xff for an SD card
+            --tx_remain;
+        }
+        if (rx_remain && !pio_sm_is_rx_fifo_empty(spi->pio, spi->sm)) {
+            *dst++ = *rxfifo;
+            --rx_remain;
+        }
+    }
+}
+

--- a/Kernel/platform-rpipico/pio_spi_sdcard.h
+++ b/Kernel/platform-rpipico/pio_spi_sdcard.h
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef _PIO_SPI_H
+#define _PIO_SPI_H
+
+#include "hardware/pio.h"
+#include "spi_sdcard.pio.h"
+
+typedef struct pio_spi_inst {
+    PIO pio;
+    uint sm;
+    uint cs_pin;
+} pio_spi_inst_t;
+
+void pio_spi_write8_blocking(const pio_spi_inst_t *spi, const uint8_t *src, size_t len);
+
+void pio_spi_read8_blocking(const pio_spi_inst_t *spi, uint8_t *dst, size_t len);
+
+#endif

--- a/Kernel/platform-rpipico/spi_sdcard.pio
+++ b/Kernel/platform-rpipico/spi_sdcard.pio
@@ -1,0 +1,73 @@
+;
+; Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+;
+; SPDX-License-Identifier: BSD-3-Clause
+;
+
+;cut out auto CS version for 2021mar06 experiment, based on pio/spi example
+;cut out spi_cpha1 2021mar13 as not needed
+
+; This program implement full-duplex SPI, with a SCK period of 4 clock
+; cycles. CPHA = 0, and CPOL = 0, 8 bit 
+;
+
+
+.program spi_cpha0
+.side_set 1
+
+; Pin assignments:
+; - SCK is side-set pin 0
+; - MOSI is OUT pin 0
+; - MISO is IN pin 0
+;
+; Autopush and autopull must be enabled, and the serial frame size is set by
+; configuring the push/pull threshold. Shift left/right is fine, but you must
+; justify the data yourself. This is done most conveniently for frame sizes of
+; 8 or 16 bits by using the narrow store replication and narrow load byte
+; picking behaviour of RP2040's IO fabric.
+
+; Clock phase = 0: data is captured on the leading edge of each SCK pulse, and
+; transitions on the trailing edge, or some time before the first leading edge.
+
+    out pins, 1 side 0 [1] ; Stall here on empty (sideset proceeds even if
+    in pins, 1  side 1 [1] ; instruction stalls, so we stall with SCK low)
+
+% c-sdk {
+#include "hardware/gpio.h"
+static inline void pio_spi_init(PIO pio, uint sm, uint prog_offs,
+        float clkdiv, uint pin_sck, uint pin_mosi, uint pin_miso) {
+    pio_sm_config c = spi_cpha0_program_get_default_config(prog_offs); //CPHA=0
+    sm_config_set_out_pins(&c, pin_mosi, 1);
+    sm_config_set_in_pins(&c, pin_miso);
+    sm_config_set_sideset_pins(&c, pin_sck);
+    // Only support MSB-first in this example code (shift to left, auto push/pull, threshold=nbits)
+    sm_config_set_out_shift(&c, false, true, 8);
+    sm_config_set_in_shift(&c, false, true, 8);
+    sm_config_set_clkdiv(&c, clkdiv);
+
+    // MOSI, SCK output are low, MISO is input
+    pio_sm_set_pins_with_mask(pio, sm, 0, (1u << pin_sck) | (1u << pin_mosi));
+    pio_sm_set_pindirs_with_mask(pio, sm, (1u << pin_sck) | (1u << pin_mosi), (1u << pin_sck) | (1u << pin_mosi) | (1u << pin_miso));
+    pio_gpio_init(pio, pin_mosi);
+    pio_gpio_init(pio, pin_miso);
+    pio_gpio_init(pio, pin_sck);
+
+    // The pin muxes can be configured to invert the output (among other things
+    // and this is a cheesy way to get CPOL=1, but here we are using CPOL=0
+    gpio_set_outover(pin_sck, GPIO_OVERRIDE_NORMAL);  //CPOL=0
+    // SPI is synchronous, so bypass input synchroniser to reduce input delay.
+    hw_set_bits(&pio->input_sync_bypass, 1u << pin_miso);
+
+    pio_sm_init(pio, sm, prog_offs, &c);
+    pio_sm_set_enabled(pio, sm, true);
+}
+
+static inline void pio_spi_disable(PIO pio, uint sm) {
+    pio_sm_set_enabled(pio, sm, false);
+}
+
+static inline void pio_spi_enable(PIO pio, uint sm) {
+    pio_sm_set_enabled(pio, sm, true);
+}
+%}
+


### PR DESCRIPTION
I think the Makefile 'pico' or 'vgaboard' selection could be better.
I didn't want to add a header file for GPIO #defines so right now so they are in the body of devsdspi.c
which set of #defines gets included is controlled from the Makefile.
I don't know cmake yet so there is probably a better way.

I'm guessing the PIO could be clocked a little faster, but I trashed 1 sd card in early days testing so kept 4MHz clock as max frequency. Also I don't have a scope to look at the signals.

Maybe you'd want to pull out the comments from devsdspi.c and do something with them to readme

The pico build wiring is the same as your original.

If this end up in Alan Cox's intray by mistake because of my inexperience with git then apologies.